### PR TITLE
LEAR-205: Remove input field project-name while making crud automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ create:
 crud:
 	bash automate/scripts/crud.sh
 
-
 .PHONY: migrate-up migrate-down force goto drop create
 
 .PHONY: migrate-up migrate-down force goto drop create auto-create

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ create:
 crud:
 	bash automate/scripts/crud.sh
 
+
 .PHONY: migrate-up migrate-down force goto drop create
 
 .PHONY: migrate-up migrate-down force goto drop create auto-create

--- a/automate/scripts/crud.sh
+++ b/automate/scripts/crud.sh
@@ -17,7 +17,6 @@ first_lower () {
 
 printf "\n *** Go Gin GORM Scaffold Generator *** \n"
 printf "This scaffolder assumes that you are using RTW clean-gin template.\n"
-echo "Enter project name (eg: ecommerce-api):"; read project_name
 echo "Enter resource name(eg: ProductCategory):"; read uc_resource
 echo "Enter resource table name(eg: product_category):"; read resource_table
 echo "Enter plural resource table name(eg: product_categories):"; read plural_resource_table
@@ -29,6 +28,9 @@ ROOT=$(pwd)
 
 printf "\n* Generating Scaffold for ${uc_resource} *\n\n"
 
+# getting project name from go.mod file
+# this code will grab second word of first line from file go.mod and store value to the project name
+read -r _ project_name _ < go.mod
 
 placeholder_value_hash=(
   "{{ucresource}}:$uc_resource"


### PR DESCRIPTION
https://readytowork.atlassian.net/browse/LEAR-205

Before: We had to enter project-name every time we perform crud automation.

Now: We are reading project name from go.mod file instead of taking user input 