### PR TITLE
Automatically Delete old versions of service from app engine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,19 @@ jobs:
           name: Deploy CRON to Google App Engine Cloud Scheduler
           command: |
             gcloud app deploy cron.yaml --quiet
+            
+      - run:
+          name: Delete Old versions of App Engine
+          command: |
+            versions=$(gcloud app versions list \
+              --service default \
+              --sort-by '~VERSION.ID' \
+              --format 'value(VERSION.ID)' | sed 1,5d)
+            for version in $versions; do
+              gcloud app versions delete "$version" \
+                --service default \
+                --quiet
+            done
 
       - slack/status:
           channel: ${SLACK_CHANNEL}


### PR DESCRIPTION
Problem:
- We are constantly facing this problem in every project. Where we have to manually delete versions from app engine due to more than 210 versions
![Screen Shot 2022-10-28 at 2 48 46 PM](https://user-images.githubusercontent.com/24245297/198549717-cd81ee47-904c-482c-9eb0-8a11e7821556.jpg)

What I did?
- Created a script to delete all versions other than last 5 versions.

With this we can save time and some costing in GCP 🙇 